### PR TITLE
feat: add auto-assignment policy support

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -27,5 +27,13 @@ locals {
     ]
   ])
 
-  resource-catalog-associations-filtered = values(zipmap(local.resources[*].catalog_resource_association_key, local.resources)) # Goes through the list of resource objects and removes duplicates, keeping the last instance in the list
+  resource-catalog-associations-filtered = [                                                                                                                 # Goes through the list of resource objects and removes duplicates, keeping the last instance in the list
+    for resource in values(zipmap(local.resources[*].catalog_resource_association_key, local.resources)) : resource                                           #
+    if resource.resource_origin_system != "SharePointOnline"                                                                                                  # SharePointOnline is handled via msgraph due to https://github.com/hashicorp/terraform-provider-azuread/issues/1637
+  ]                                                                                                                                                           #
+
+  sharepoint-catalog-associations-filtered = [                                                                                                                # Deduplicated list of SharePointOnline catalog associations
+    for resource in values(zipmap(local.resources[*].catalog_resource_association_key, local.resources)) : resource                                           #
+    if resource.resource_origin_system == "SharePointOnline"                                                                                                  #
+  ]                                                                                                                                                           #
 }

--- a/main.tf
+++ b/main.tf
@@ -170,6 +170,51 @@ resource "azuread_access_package_assignment_policy" "assignment_policies" {
   ]
 }
 
+###   Identity Governance - Auto-Assignment Policies
+###   Created only when auto_assignment_policy is defined on an access package.
+###   These are separate from request-based policies - Entra ID automatically
+###   grants access to users matching the OData filter without requiring a request.
+###   Uses msgraph_resource directly because the azuread provider does not yet support
+###   automaticRequestSettings (https://github.com/hashicorp/terraform-provider-azuread/issues/1449)
+####################################################################################################
+resource "msgraph_resource" "auto-assignment-policies" {
+  for_each = { for ap in local.access-packages : ap.key => ap if ap.auto_assignment_policy != null }
+
+  url = "/identityGovernance/entitlementManagement/assignmentPolicies"
+
+  body = {
+    displayName          = "${each.value.display_name}-auto-assignment-policy"
+    description          = each.value.description
+    allowedTargetScope   = "specificDirectoryUsers"
+    specificAllowedTargets = [
+      {
+        "@odata.type"  = "#microsoft.graph.attributeRuleMembers"
+        description    = "Attribute rule for auto-assignment"
+        membershipRule = each.value.auto_assignment_policy.filter
+      }
+    ]
+    automaticRequestSettings = {
+      requestAccessForAllowedTargets             = true
+      removeAccessWhenTargetLeavesAllowedTargets = each.value.auto_assignment_policy.remove_when_target_leaves
+      gracePeriodBeforeAccessRemoval             = each.value.auto_assignment_policy.grace_period_before_removal
+    }
+    accessPackage = {
+      id = azuread_access_package.access-packages[each.key].id
+    }
+  }
+
+  response_export_values = {
+    id = "id"
+  }
+
+  depends_on = [
+    azuread_access_package_catalog.entitlement-catalogs,
+    azuread_access_package.access-packages,
+    azuread_access_package_resource_catalog_association.resource-catalog-associations,
+    azuread_access_package_resource_package_association.resource-access-package-associations
+  ]
+}
+
 ###   Identity Governance - Resource Catalog Associations
 ############################################################
 resource "azuread_access_package_resource_catalog_association" "resource-catalog-associations" {

--- a/main.tf
+++ b/main.tf
@@ -187,7 +187,7 @@ resource "azuread_access_package_resource_catalog_association" "resource-catalog
 ###   Identity Governance - Resource Access Package Associations
 ###################################################################
 resource "azuread_access_package_resource_package_association" "resource-access-package-associations" {
-  for_each = { for resource in local.resources : resource.access_package_resource_association_key => resource if resource.resource_origin_system != "AadApplication" }
+  for_each = { for resource in local.resources : resource.access_package_resource_association_key => resource if resource.resource_origin_system != "AadApplication" && resource.resource_origin_system != "SharePointOnline" }
 
   catalog_resource_association_id = azuread_access_package_resource_catalog_association.resource-catalog-associations[each.value.catalog_resource_association_key].id
   access_package_id               = azuread_access_package.access-packages[each.value.access_package_key].id
@@ -238,6 +238,106 @@ data "msgraph_resource" "resource_access_package_catalog_resource_roles" {
     azuread_access_package_catalog.entitlement-catalogs,
     azuread_access_package.access-packages,
     azuread_access_package_resource_catalog_association.resource-catalog-associations
+  ]
+}
+
+###   Identity Governance - Resource Catalog Associations for SharePointOnline
+###   due to https://github.com/hashicorp/terraform-provider-azuread/issues/1637
+###################################################################
+resource "msgraph_resource_action" "sharepoint-catalog-associations" {
+  for_each     = { for resource in local.sharepoint-catalog-associations-filtered : resource.catalog_resource_association_key => resource }
+  resource_url = "/identityGovernance/entitlementManagement/resourceRequests"
+  method       = "POST"
+
+  body = {
+    requestType  = "AdminAdd"
+    justification = ""
+    resource = {
+      originId     = each.value.resource_origin_id
+      originSystem = "SharePointOnline"
+    }
+    catalog = {
+      id = azuread_access_package_catalog.entitlement-catalogs[each.value.catalog_key].id
+    }
+  }
+
+  depends_on = [
+    azuread_access_package_catalog.entitlement-catalogs
+  ]
+}
+
+data "msgraph_resource" "sharepoint_catalog_resources" {
+  for_each = { for resource in local.resources : resource.access_package_resource_association_key => resource if resource.resource_origin_system == "SharePointOnline" }
+  url      = "/identityGovernance/entitlementManagement/catalogs/${azuread_access_package_catalog.entitlement-catalogs[each.value.catalog_key].id}/resources"
+  query_parameters = {
+    "$filter" = ["(originId eq '${each.value.resource_origin_id}')"]
+    "$expand" = ["scopes"]
+  }
+  response_export_values = {
+    all      = "@"
+    id       = "value[0].id"
+    scope_id = "value[0].scopes[0].id"
+  }
+
+  depends_on = [
+    azuread_access_package_catalog.entitlement-catalogs,
+    msgraph_resource_action.sharepoint-catalog-associations
+  ]
+}
+
+data "msgraph_resource" "sharepoint_catalog_resource_roles" {
+  for_each = { for resource in local.resources : resource.access_package_resource_association_key => resource if resource.resource_origin_system == "SharePointOnline" }
+  url      = "/identityGovernance/entitlementManagement/catalogs/${azuread_access_package_catalog.entitlement-catalogs[each.value.catalog_key].id}/resourceRoles"
+  query_parameters = {
+    "$filter" = ["(originSystem eq 'SharePointOnline' and resource/id eq '${data.msgraph_resource.sharepoint_catalog_resources[each.key].output.id}')"]
+    "$expand" = ["resource"]
+  }
+  response_export_values = {
+    all          = "@"
+    id           = "value[0].id"
+    display_name = "value[0].displayName"
+    origin_id    = "value[0].originId"
+  }
+
+  depends_on = [
+    azuread_access_package_catalog.entitlement-catalogs,
+    msgraph_resource_action.sharepoint-catalog-associations,
+    data.msgraph_resource.sharepoint_catalog_resources
+  ]
+}
+
+###   Identity Governance - Resource Access Package Associations for SharePointOnline
+###   due to https://github.com/hashicorp/terraform-provider-azuread/issues/1637
+###################################################################
+resource "msgraph_resource_action" "sharepoint-access-package-associations" {
+  for_each     = { for resource in local.resources : resource.access_package_resource_association_key => resource if resource.resource_origin_system == "SharePointOnline" }
+  resource_url = "/identityGovernance/entitlementManagement/accessPackages/${azuread_access_package.access-packages[each.value.access_package_key].id}/resourceRoleScopes"
+  method       = "POST"
+
+  body = {
+    role = {
+      displayName  = data.msgraph_resource.sharepoint_catalog_resource_roles[each.key].output.display_name
+      originSystem = "SharePointOnline"
+      originId     = data.msgraph_resource.sharepoint_catalog_resource_roles[each.key].output.origin_id
+      resource = {
+        id = data.msgraph_resource.sharepoint_catalog_resources[each.key].output.id
+      }
+    }
+    scope = {
+      displayName  = "Root"
+      description  = "Root Scope"
+      originId     = each.value.resource_origin_id
+      originSystem = "SharePointOnline"
+      isRootScope  = true
+    }
+  }
+
+  depends_on = [
+    azuread_access_package_catalog.entitlement-catalogs,
+    azuread_access_package.access-packages,
+    msgraph_resource_action.sharepoint-catalog-associations,
+    data.msgraph_resource.sharepoint_catalog_resources,
+    data.msgraph_resource.sharepoint_catalog_resource_roles
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -94,6 +94,12 @@ variable "entitlement_catalogs" {
         })))
       })))
 
+      auto_assignment_policy = optional(object({
+        filter                      = string                   # OData filter expression identifying users to auto-assign, e.g. "(user.department -eq \"Engineering\")"
+        remove_when_target_leaves   = optional(bool, true)    # Revoke access when the user no longer matches the filter. Defaults to true
+        grace_period_before_removal = optional(string, "P7D") # ISO 8601 duration to wait before revoking access after a user leaves scope. Defaults to 7 days
+      }))
+
       resources = list(object({                             # List of resources, one resource per object
         display_name           = optional(string)           # Deprecated! Descriptive display name to be used for the Terraform Resource key
         resource_origin_system = string                     # The type of resource in the origin system. "SharePointOnline", "AadApplication", "AadGroup"


### PR DESCRIPTION
## Summary

Adds support for [automatic assignment policies](https://learn.microsoft.com/en-us/entra/id-governance/entitlement-management-access-package-auto-assignment-policy) in Entitlement Management packages that automatically grant access to users matching an OData filter, with no request or approval required.

The `azuread` provider does not yet support `automaticRequestSettings`([hashicorp/terraform-provider-azuread#1449](https://github.com/hashicorp/terraform-provider-azuread/issues/1449)), so this uses the `microsoft/msgraph` provider directly via the Graph API, following the same pattern already established in this module for SharePoint resource associations.

## Changes
**`variables.tf ` added in an `auto_assignment_policy` block on each access package:

```hcl
auto_assignment_policy = optional(object({
    filter                                         = string                   # OData filter expression
    remove_when_target_leaves   = optional(bool, true)
    grace_period_before_removal = optional(string, "P7D")
}))
```
**`main.tf`** adds `msgraph_resource "auto-assignment-policies"`, only created when `auto_assignment_policy` is defined on a package. 
Calls `POST /identityGovernance/entitlementManagement/assignmentPolicies` with `allowedTargetScope = specificDirectoryUsers` and `automaticRequestSettings`.

## Usage
```hcl
  entitlement_catalogs = [{
    display_name = "new-hires"
    description  = "New hire onboarding access"

    access_packages = [{
      display_name = "engineering-members"
      description  = "Engineering department access"

      auto_assignment_policy = {
        filter                      = "(user.department -eq \"Engineering\")"
        remove_when_target_leaves   = true
        grace_period_before_removal = "P7D"
      }

      resources = [{
        resource_origin_system = "AadGroup"
        resource_origin_id     = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
        access_type            = "Member"
      }]
    }]
  }]
```

## Notes

- This branch also contains the SharePoint msgraph fix from PR #309. If #309 merges first, the diff here will reduce to only the auto-assignment changes.
- The `filter` field accepts any valid Entra ID [dynamic membership rule expression](https://learn.microsoft.com/en-us/entra/identity/users/groups-dynamic-membership).
- Packages without `auto_assignment_policy` are unaffected - existing request-based policy behavior is unchanged.

thanks for team that's been maintaining it really appreciate the repo. Happy to update and make any changes needed, and any feedback whenever you get a moment is very welcomed! Thank you just a but eager.